### PR TITLE
completed the APIs for Purchase order and opened purchase orders

### DIFF
--- a/cubeseed/purchase_orders/admin.py
+++ b/cubeseed/purchase_orders/admin.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+from .models import PurchaseOrder, OpenedPurchaseOrder
+
+# Register your models here.
+admin.site.register(PurchaseOrder)
+admin.site.register(OpenedPurchaseOrder)

--- a/cubeseed/purchase_orders/apps.py
+++ b/cubeseed/purchase_orders/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class PurchaseOrdersConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'cubeseed.purchase_orders'

--- a/cubeseed/purchase_orders/models.py
+++ b/cubeseed/purchase_orders/models.py
@@ -16,7 +16,11 @@ class PurchaseOrder(models.Model):
     price = models.DecimalField(max_digits=10, decimal_places=2)
     buyer_name = models.CharField(max_length=255)
     terms_and_conditions = models.TextField()
-    accepted_by = models.ForeignKey(User, null=True, blank=True, on_delete=models.SET_NULL)
+    status = models.CharField(max_length=20, choices=(
+                                                      ("pending", "Pending"),
+                                                      ("accepted", "Accepted"),
+                                                      ("rejected", "Rejected")), default="pending")
+    accepted_by = models.ForeignKey(User, null=True, blank=True, on_delete=models.SET_NULL, related_name="accepted_orders")
 
     def __str__(self):
         return f"{self.name}"

--- a/cubeseed/purchase_orders/models.py
+++ b/cubeseed/purchase_orders/models.py
@@ -1,0 +1,28 @@
+from django.db import models
+from django.contrib.auth.models import User
+import uuid
+
+# For creating the purchase order
+class PurchaseOrder(models.Model):
+    name = models.CharField(max_length=255)
+    order_number = models.CharField(max_length=32, unique=True, default=uuid.uuid4, editable=False)
+    date_sent = models.DateField()
+    delivery_date = models.DateField()
+    delivery_venue = models.CharField(max_length=255)
+    products = models.TextField()
+    price = models.DecimalField(max_digits=10, decimal_places=2)
+    buyer_name = models.CharField(max_length=255)
+    terms_and_conditions = models.TextField()
+    accepted_by = models.ForeignKey(User, null=True, blank=True, on_delete=models.SET_NULL)
+
+    def __str__(self):
+        return self.name
+
+
+class OpenedPurchaseOrder(models.Model):
+    """Orders opened by the farmer"""
+    purchase_order = models.ForeignKey(PurchaseOrder, on_delete=models.CASCADE)
+    farmer = models.ForeignKey(User, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return f"{self.farmer.username} - {self.purchase_order.name}"

--- a/cubeseed/purchase_orders/models.py
+++ b/cubeseed/purchase_orders/models.py
@@ -1,6 +1,9 @@
-from django.db import models
-from django.contrib.auth.models import User
 import uuid
+# pylint: disable=imported-auth-user
+from django.contrib.auth.models import User
+
+from django.db import models
+
 
 # For creating the purchase order
 class PurchaseOrder(models.Model):
@@ -16,7 +19,7 @@ class PurchaseOrder(models.Model):
     accepted_by = models.ForeignKey(User, null=True, blank=True, on_delete=models.SET_NULL)
 
     def __str__(self):
-        return self.name
+        return f"{self.name}"
 
 
 class OpenedPurchaseOrder(models.Model):

--- a/cubeseed/purchase_orders/serializer.py
+++ b/cubeseed/purchase_orders/serializer.py
@@ -1,0 +1,12 @@
+from rest_framework import serializers
+from .models import PurchaseOrder, OpenedPurchaseOrder
+
+class PurchaseOrderSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PurchaseOrder
+        fields = '__all__'
+
+class OpendPurchaseOrderSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = OpenedPurchaseOrder
+        fields = '__all__'

--- a/cubeseed/purchase_orders/tests.py
+++ b/cubeseed/purchase_orders/tests.py
@@ -1,0 +1,236 @@
+from rest_framework.test import APITestCase
+from .models import PurchaseOrder, OpenedPurchaseOrder
+from django.contrib.auth import get_user_model
+from rest_framework_simplejwt.tokens import RefreshToken
+from django.urls import reverse
+from rest_framework import status
+
+
+class PurchaseOrderTestCase(APITestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="testuser", password="testpassword")
+
+        # generate the token and add it to the auth header
+        refresh = RefreshToken.for_user(self.user)
+        self.token_value = str(refresh.access_token)
+        self.auth_header = f"Bearer {self.token_value}"
+        self.purchase_order = PurchaseOrder.objects.create(
+            name="test purchase order",
+            date_sent="2021-01-01",
+            delivery_date="2021-01-01",
+            delivery_venue="test venue",
+            products="test products",
+            price=100.00,
+            buyer_name="test buyer",
+            terms_and_conditions="test terms and conditions"
+        )
+
+    # POST route
+    def test_create_purchase_order(self):
+        url = reverse("purchaseorder-list")
+        data = {
+            "name": "new purchase order",
+            "date_sent": "2021-02-02",
+            "delivery_date": "2021-02-02",
+            "delivery_venue": "new venue",
+            "products": "new products",
+            "price": 200.00,
+            "buyer_name": "new buyer",
+            "terms_and_conditions": "new terms and conditions"
+        }
+
+        response = self.client.post(url, data, format="json", HTTP_AUTHORIZATION=self.auth_header)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(PurchaseOrder.objects.count(), 2)
+
+    # GET route
+    def test_get_purchase_order(self):
+        purchase_order = self.purchase_order
+
+        url = reverse("purchaseorder-detail", kwargs={"pk": purchase_order.id})
+        response = self.client.get(url, HTTP_AUTHORIZATION=self.auth_header)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # convert the price to string to compare with the response data
+        expected_price = "{:.2f}".format(purchase_order.price)
+
+        # chack if the response data is the same as the created purchase order
+        self.assertEqual(response.data["name"], purchase_order.name)
+        self.assertEqual(response.data["date_sent"], purchase_order.date_sent)
+        self.assertEqual(response.data["delivery_date"], purchase_order.delivery_date)
+        self.assertEqual(response.data["delivery_venue"], purchase_order.delivery_venue)
+        self.assertEqual(response.data["products"], purchase_order.products)
+        self.assertEqual(response.data["price"], expected_price)
+        self.assertEqual(response.data["buyer_name"], purchase_order.buyer_name)
+        self.assertEqual(response.data["terms_and_conditions"], purchase_order.terms_and_conditions)
+
+    # PUT route
+    def test_update_purchase_order(self):
+        purchase_order = self.purchase_order
+
+        url = reverse("purchaseorder-detail", kwargs={"pk": purchase_order.id})
+        updated_data = {
+            "name": "Updated Order",
+            "date_sent": "2021-10-10",
+            "delivery_date": "2021-10-10",
+            "delivery_venue": "Updated Venue",
+            "products": "Updated Products",
+            "price": 200.00,
+            "buyer_name": "Updated Buyer",
+            "terms_and_conditions": "Updated Terms and Conditions"
+            }
+
+        response = self.client.put(url, updated_data, format="json", HTTP_AUTHORIZATION=self.auth_header)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # refresh the purchase order object from db
+        purchase_order.refresh_from_db()
+
+        # check if the purchase order object is updated
+        self.assertEqual(purchase_order.name, updated_data["name"])
+        self.assertEqual(str(purchase_order.date_sent), updated_data["date_sent"])
+        self.assertEqual(purchase_order.delivery_venue, updated_data["delivery_venue"])
+        self.assertEqual(str(purchase_order.delivery_date), updated_data["delivery_date"])
+        self.assertEqual(purchase_order.products, updated_data["products"])
+        self.assertEqual(purchase_order.price, updated_data["price"])
+        self.assertEqual(purchase_order.buyer_name, updated_data["buyer_name"])
+        self.assertEqual(purchase_order.terms_and_conditions, updated_data["terms_and_conditions"])
+
+    # PATCH route
+    def test_partial_update_purchase_order(self):
+        purchase_order = self.purchase_order
+
+        url = reverse("purchaseorder-detail", kwargs={"pk": purchase_order.id})
+        updated_data = {
+            "name": "Updated Order",
+            "delivery_venue": "Updated Venue",
+            "price": 200.00,
+        }
+
+        response = self.client.patch(url, updated_data, format="json", HTTP_AUTHORIZATION=self.auth_header)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Refresh the db
+        purchase_order.refresh_from_db()
+
+        # confirm the purchase order is updated properly
+        self.assertEqual(purchase_order.name, updated_data["name"])
+        self.assertEqual(purchase_order.delivery_venue, updated_data["delivery_venue"])
+        self.assertEqual(purchase_order.price, updated_data["price"])
+
+    # DELETE route
+    def test_delete_purchase_order(self):
+        purchase_order = self.purchase_order
+
+        url = reverse("purchaseorder-detail", kwargs={"pk": purchase_order.id})
+        response = self.client.delete(url, HTTP_AUTHORIZATION=self.auth_header)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(PurchaseOrder.objects.count(), 0)
+
+
+class OpenedPurchaseOrderTestCase(APITestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="testuser", password="testpassword")
+
+        # generate the token and add it to the auth header
+        refresh = RefreshToken.for_user(self.user)
+        self.token_value = str(refresh.access_token)
+        self.auth_header = f"Bearer {self.token_value}"
+
+        # create the purchase order object
+        self.purchase_order = PurchaseOrder.objects.create(
+            name="test purchase order",
+            date_sent="2021-01-01",
+            delivery_date="2021-01-01",
+            delivery_venue="test venue",
+            products="test products",
+            price=100.00,
+            buyer_name="test buyer",
+            terms_and_conditions="test terms and conditions"
+        )
+
+    # POST route
+    def test_create_opened_purchase_order(self):
+
+        url = reverse("openedpurchaseorder-list")
+        data = {
+            "purchase_order": self.purchase_order.id,
+            "farmer": self.user.id
+        }
+
+        response = self.client.post(url, data, format="json", HTTP_AUTHORIZATION=self.auth_header)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(OpenedPurchaseOrder.objects.count(), 1)
+
+    # GET route
+    def test_get_opened_purchase_order(self):
+        opened_purchase_order = OpenedPurchaseOrder.objects.create(
+            purchase_order=self.purchase_order,
+            farmer=self.user
+        )
+
+        url = reverse("openedpurchaseorder-detail", kwargs={"pk": opened_purchase_order.id})
+        response = self.client.get(url, HTTP_AUTHORIZATION=self.auth_header)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # check if the response data is the same as the created purchase order
+        self.assertEqual(response.data["purchase_order"], opened_purchase_order.purchase_order.id)
+        self.assertEqual(response.data["farmer"], opened_purchase_order.farmer.id)
+
+    # PUT route
+    def test_update_opened_purchase_order(self):
+        opened_purchase_order = OpenedPurchaseOrder.objects.create(
+            purchase_order=self.purchase_order,
+            farmer=self.user
+        )
+
+        url = reverse("openedpurchaseorder-detail", kwargs={"pk": opened_purchase_order.id})
+        updated_data = {
+            "purchase_order": self.purchase_order.id,
+            "farmer": self.user.id
+        }
+
+        response = self.client.put(url, updated_data, format="json", HTTP_AUTHORIZATION=self.auth_header)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # refresh the purchase order object from db
+        opened_purchase_order.refresh_from_db()
+
+        # check if the purchase order object is updated
+        self.assertEqual(opened_purchase_order.purchase_order.id, updated_data["purchase_order"])
+        self.assertEqual(opened_purchase_order.farmer.id, updated_data["farmer"])
+
+    # PATCH route
+    def test_partial_update_opened_purchase_order(self):
+        opened_purchase_order = OpenedPurchaseOrder.objects.create(
+            purchase_order=self.purchase_order,
+            farmer=self.user
+        )
+
+        url = reverse("openedpurchaseorder-detail", kwargs={"pk": opened_purchase_order.id})
+        updated_data = {
+            "purchase_order": self.purchase_order.id,
+        }
+
+        response = self.client.patch(url, updated_data, format="json", HTTP_AUTHORIZATION=self.auth_header)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # refresh the purchase order object from db
+        opened_purchase_order.refresh_from_db()
+
+        # check if the purchase order object is updated
+        self.assertEqual(opened_purchase_order.purchase_order.id, updated_data["purchase_order"])
+
+    # DELETE route
+    def test_delete_opened_purchase_order(self):
+        opened_purchase_order = OpenedPurchaseOrder.objects.create(
+            purchase_order=self.purchase_order,
+            farmer=self.user
+        )
+
+        url = reverse("openedpurchaseorder-detail", kwargs={"pk": opened_purchase_order.id})
+        response = self.client.delete(url, HTTP_AUTHORIZATION=self.auth_header)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(OpenedPurchaseOrder.objects.count(), 0)

--- a/cubeseed/purchase_orders/urls.py
+++ b/cubeseed/purchase_orders/urls.py
@@ -1,0 +1,10 @@
+from rest_framework.routers import DefaultRouter
+from .views import PurchasedOrderViewSet, OpenedPurchaseOrderViewSet
+
+def register_routes(router):
+    router.register(r"purchase-orders", PurchasedOrderViewSet)
+    router.register(r"opened-purchase-orders", OpenedPurchaseOrderViewSet)
+
+    return router
+
+url_patterns = register_routes(DefaultRouter()).urls

--- a/cubeseed/purchase_orders/views.py
+++ b/cubeseed/purchase_orders/views.py
@@ -1,12 +1,36 @@
-from rest_framework import viewsets, permissions
+from rest_framework import viewsets, permissions, status
+from rest_framework.decorators import action
+from rest_framework.response import Response
 from .models import PurchaseOrder, OpenedPurchaseOrder
 from .serializer import PurchaseOrderSerializer, OpendPurchaseOrderSerializer
+
 
 class PurchasedOrderViewSet(viewsets.ModelViewSet):
     queryset = PurchaseOrder.objects.all()
     serializer_class = PurchaseOrderSerializer
     permission_classes = [permissions.IsAuthenticated]
     http_method_names = ["get", "post", "put", "patch", "delete"]
+
+    # custom action to accept a purchase order
+    @action(detail=True, methods=["post"])
+    def accept_order(self, request, pk=None):
+        purchase_order = self.get_object()
+
+        # check if the purchase order has already been accepted/bought by other person
+        if purchase_order.accepted_by is not None:
+            return Response({"detail": "This purchase order is already accepted."}, status=status.HTTP_400_BAD_REQUEST)
+
+        # update the purchase order's accepted_by field to the current user
+        purchase_order.accepted_by = request.user
+        purchase_order.save()
+
+        # Create an openedPurchaseOrder object entery for the accepted order
+        opened_purchase_order = OpenedPurchaseOrder.objects.create(purchase_order=purchase_order, farmer=request.user)
+        opened_purchase_order.save()
+
+        # Serialize the updated purchase order and return the response
+        serializer = self.get_serializer(purchase_order)
+        return Response(serializer.data)
 
 class OpenedPurchaseOrderViewSet(viewsets.ModelViewSet):
     queryset = OpenedPurchaseOrder.objects.all()

--- a/cubeseed/purchase_orders/views.py
+++ b/cubeseed/purchase_orders/views.py
@@ -1,0 +1,15 @@
+from rest_framework import viewsets, permissions
+from .models import PurchaseOrder, OpenedPurchaseOrder
+from .serializer import PurchaseOrderSerializer, OpendPurchaseOrderSerializer
+
+class PurchasedOrderViewSet(viewsets.ModelViewSet):
+    queryset = PurchaseOrder.objects.all()
+    serializer_class = PurchaseOrderSerializer
+    permission_classes = [permissions.IsAuthenticated]
+    http_method_names = ["get", "post", "put", "patch", "delete"]
+
+class OpenedPurchaseOrderViewSet(viewsets.ModelViewSet):
+    queryset = OpenedPurchaseOrder.objects.all()
+    serializer_class = OpendPurchaseOrderSerializer
+    permission_classes = [permissions.IsAuthenticated]
+    http_method_names = ["get", "post", "put", "patch", "delete"]

--- a/cubeseed/settings.py
+++ b/cubeseed/settings.py
@@ -67,6 +67,7 @@ INSTALLED_APPS = [
     "cubeseed.cluster",
     "cubeseed.course",
     "cubeseed.course_verification",
+    "cubeseed.purchase_orders",
     "drf_yasg",
     "corsheaders",
 ]

--- a/cubeseed/urls.py
+++ b/cubeseed/urls.py
@@ -41,6 +41,8 @@ from cubeseed.farm.views import FarmViewSet, FarmInClusterViewSet
 from cubeseed.course.urls import register_routes as register_course_routes
 from cubeseed.course_verification.urls import register_routes as register_course_verification_routes
 
+from cubeseed.purchase_orders.urls import register_routes as register_purchase_orders_routes
+
 
 SchemaView = get_schema_view(
     openapi.Info(
@@ -64,6 +66,7 @@ register_commodity_routes(router)
 
 register_course_routes(router)
 register_course_verification_routes(router)
+register_purchase_orders_routes(router)
 
 
 router.register(r"address", AddressViewSet)


### PR DESCRIPTION
Note: He views the Purchase order and accepts it. When he decides to log off and comes back again. He finds out he can only find the Purchase Order he accepted in Opened Purchase Orders. 

Basic Flow:
John searches for projects to start by clicking Purchase Orders
A list of sent Purchase Orders are displayed
He clicks on one and it takes him to Purchase Order which shows him details of the Purchase Order. Details are:
        -The Purchase Order name
        -The Purchase Order number
        -The date it was sent
        -Date of Product delivery
        -The venue of the Delivery
        -List of Products
        -Price to be paid for the products to be produced
        -Buyer’s name
        -Brief terms and conditions
He clicks accept if he wants to take on the project
The Farm planner workspace loads for that Purchase Order


Postconditions:
He get’s directed to Farm Planner workspace
The purchase order accepted moves to Opened Purchase Orders
